### PR TITLE
improvements to the gemstash-specific build process

### DIFF
--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlipFab
-  base = '1.0.5'
+  base = '1.0.6'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module FlipFab
-  VERSION = '1.0.5' # rubocop:disable Style/MutableConstant
+  base = '1.0.5'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
-  VERSION << '.' << ENV['GEM_PRE_RELEASE'].strip \
-  unless ENV.fetch('GEM_PRE_RELEASE', '').strip.empty?
+  VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
 end


### PR DESCRIPTION
upgrade versioning logic for dependabot

upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities