### PR TITLE
Removing domain parameter in flip fan generated cookie

### DIFF
--- a/lib/flip_fab/cookie_persistence.rb
+++ b/lib/flip_fab/cookie_persistence.rb
@@ -17,7 +17,6 @@ module FlipFab
       cookie_domain = ".#{top_level_domain}" unless top_level_domain.nil?
       context.response.set_cookie key, value:   state,
                                        expires: cookie_expiration,
-                                       domain:  cookie_domain,
                                        path:    COOKIE_PATH
     end
 

--- a/lib/flip_fab/cookie_persistence.rb
+++ b/lib/flip_fab/cookie_persistence.rb
@@ -17,8 +17,7 @@ module FlipFab
       cookie_domain = ".#{top_level_domain}" unless top_level_domain.nil?
       context.response.set_cookie key, value:   state,
                                        expires: cookie_expiration,
-                                       path:    '/',
-                                       secure: true
+                                       path:    COOKIE_PATH
     end
 
     private

--- a/lib/flip_fab/cookie_persistence.rb
+++ b/lib/flip_fab/cookie_persistence.rb
@@ -14,7 +14,6 @@ module FlipFab
     end
 
     def write(state)
-      cookie_domain = ".#{top_level_domain}" unless top_level_domain.nil?
       context.response.set_cookie key, value:   state,
                                        expires: cookie_expiration,
                                        path:    COOKIE_PATH

--- a/lib/flip_fab/cookie_persistence.rb
+++ b/lib/flip_fab/cookie_persistence.rb
@@ -17,7 +17,8 @@ module FlipFab
       cookie_domain = ".#{top_level_domain}" unless top_level_domain.nil?
       context.response.set_cookie key, value:   state,
                                        expires: cookie_expiration,
-                                       path:    COOKIE_PATH
+                                       path:    '/',
+                                       secure: true
     end
 
     private

--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlipFab
-  base = '1.0.9'
+  base = '1.0.10'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/spec/lib/flip_fab/cookie_persistence.feature
+++ b/spec/lib/flip_fab/cookie_persistence.feature
@@ -10,6 +10,21 @@ Feature: Persisting the feature state in a cookie
     When I persist the feature state in a cookie
     Then the cookie has the path '/'
 
+  Scenario Outline: The cookie populated should not contain domain
+    Given the host is '<host>'
+     When I persist the feature state in a cookie
+     Then the cookie does not have domain '<cookie domain>'
+
+    Examples:
+      | host                           | cookie domain         |
+      | localhost                      |                       |
+      | 127.0.0.1                      |                       |
+      | 192.168.2.40                   |                       |
+      | www.simplybusiness.co.uk       | .simplybusiness.co.uk |
+      | www.quote.simplybusiness.co.uk | .simplybusiness.co.uk |
+      | simplybusiness.co.uk           | .simplybusiness.co.uk |
+      | www.simplybusiness.com         | .simplybusiness.com   |
+
   Scenario Outline: The cookie should be named using the name of the gem and name of feature, concatenated with a dot
     Given the feature name is '<feature name>'
      When I persist the feature state in a cookie

--- a/spec/lib/flip_fab/cookie_persistence.feature
+++ b/spec/lib/flip_fab/cookie_persistence.feature
@@ -10,21 +10,6 @@ Feature: Persisting the feature state in a cookie
     When I persist the feature state in a cookie
     Then the cookie has the path '/'
 
-  Scenario Outline: The cookie should apply for all domains under the top-level domain (no domain for localhost or IP addresses, however)
-    Given the host is '<host>'
-     When I persist the feature state in a cookie
-     Then the cookie has the domain '<cookie domain>'
-
-    Examples:
-      | host                           | cookie domain         |
-      | localhost                      |                       |
-      | 127.0.0.1                      |                       |
-      | 192.168.2.40                   |                       |
-      | www.simplybusiness.co.uk       | .simplybusiness.co.uk |
-      | www.quote.simplybusiness.co.uk | .simplybusiness.co.uk |
-      | simplybusiness.co.uk           | .simplybusiness.co.uk |
-      | www.simplybusiness.com         | .simplybusiness.com   |
-
   Scenario Outline: The cookie should be named using the name of the gem and name of feature, concatenated with a dot
     Given the feature name is '<feature name>'
      When I persist the feature state in a cookie

--- a/spec/lib/flip_fab/cookie_persistence_spec.rb
+++ b/spec/lib/flip_fab/cookie_persistence_spec.rb
@@ -36,20 +36,12 @@ module FlipFab
         expect(@cookie).to match(/path=#{path};/)
       end
 
-      # step 'the cookie has the domain :domain' do |domain|
-      #   if domain == ''
-      #     expect(@cookie).not_to match(/domain/)
-      #   else
-      #     expect(@cookie).to match(/domain=#{domain};/)
-      #   end
-      # end
-
       step 'the cookie has the name :name' do |name|
         expect(@cookie).to match(/\A#{name}.*/)
       end
 
       step 'the cookie expires at :expiration' do |expiration|
-        expect(@cookie).to match("flip_fab.example_feature=enabled; path=/; expires=#{expiration}; secure")
+        expect(@cookie).to match(/expires=#{expiration}\Z/)
       end
 
       step 'the cookie value is :value' do |value|
@@ -80,7 +72,7 @@ module FlipFab
       after  { Timecop.return }
 
       it 'saves the feature state' do
-        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT; secure')
+        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT')
       end
     end
   end

--- a/spec/lib/flip_fab/cookie_persistence_spec.rb
+++ b/spec/lib/flip_fab/cookie_persistence_spec.rb
@@ -36,13 +36,13 @@ module FlipFab
         expect(@cookie).to match(/path=#{path};/)
       end
 
-      step 'the cookie has the domain :domain' do |domain|
-        if domain == ''
-          expect(@cookie).not_to match(/domain/)
-        else
-          expect(@cookie).to match(/domain=#{domain};/)
-        end
-      end
+      # step 'the cookie has the domain :domain' do |domain|
+      #   if domain == ''
+      #     expect(@cookie).not_to match(/domain/)
+      #   else
+      #     expect(@cookie).to match(/domain=#{domain};/)
+      #   end
+      # end
 
       step 'the cookie has the name :name' do |name|
         expect(@cookie).to match(/\A#{name}.*/)
@@ -80,7 +80,7 @@ module FlipFab
       after  { Timecop.return }
 
       it 'saves the feature state' do
-        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; domain=.simplybusiness.co.uk; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT')
+        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT')
       end
     end
   end

--- a/spec/lib/flip_fab/cookie_persistence_spec.rb
+++ b/spec/lib/flip_fab/cookie_persistence_spec.rb
@@ -36,6 +36,10 @@ module FlipFab
         expect(@cookie).to match(/path=#{path};/)
       end
 
+      step 'the cookie does not have domain :domain' do |domain|
+        expect(@cookie).not_to match(/domain=#{domain};/)
+      end
+
       step 'the cookie has the name :name' do |name|
         expect(@cookie).to match(/\A#{name}.*/)
       end

--- a/spec/lib/flip_fab/cookie_persistence_spec.rb
+++ b/spec/lib/flip_fab/cookie_persistence_spec.rb
@@ -49,7 +49,7 @@ module FlipFab
       end
 
       step 'the cookie expires at :expiration' do |expiration|
-        expect(@cookie).to match(/expires=#{expiration}\Z/)
+        expect(@cookie).to match("flip_fab.example_feature=enabled; path=/; expires=#{expiration}; secure")
       end
 
       step 'the cookie value is :value' do |value|
@@ -80,7 +80,7 @@ module FlipFab
       after  { Timecop.return }
 
       it 'saves the feature state' do
-        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT')
+        expect { subject.write :enabled }.to change { context.response_cookies }.from(nil).to('flip_fab.example_feature=enabled; path=/; expires=Tue, 01 Jan 1991 00:00:00 GMT; secure')
       end
     end
   end


### PR DESCRIPTION
Ticket - https://simply-business.atlassian.net/browse/ADV-661

Chopin PR - https://github.com/simplybusiness/chopin/pull/20066

Integration environment - https://chopin-make-flip-fab-partner-15f3846-a-dev-production-eu-west-1.simplybusiness.me/

1. Path hardcoded to ‘/’ - **Currently it's hardcoded**
2. Secure set to true - **If we set as secure as "true" facing failing tests with msm landlord proxy in chopin.**
3. Domain not set - **Not setting domain**

**Working as expected when domain not set.**

Below domains configured in local hosts file and tried all scenarios, refer screenshots

**1. test1.simplybusiness.me
2. test2.simplybusiness.co.uk
3. test3.simplybusiness.com
4. compatible with old cookies**

**test1.simplybusiness.me**

<img width="1352" alt="Screenshot 2020-12-01 at 18 54 27" src="https://user-images.githubusercontent.com/40201213/100806170-e9741580-3427-11eb-90cc-7571a0a6e1f1.png">

**test2.simplybusiness.com**

<img width="1589" alt="Screenshot 2020-12-01 at 19 03 47" src="https://user-images.githubusercontent.com/40201213/100806176-ebd66f80-3427-11eb-9a20-6b7b59c1a8b1.png">

**test2.simplybusiness.co.uk**

<img width="1562" alt="Screenshot 2020-12-01 at 18 55 23" src="https://user-images.githubusercontent.com/40201213/100806177-ec6f0600-3427-11eb-8412-31d7e6382892.png">

**compatible with old cookies**
<img width="1405" alt="Screenshot 2020-12-02 at 10 01 06" src="https://user-images.githubusercontent.com/40201213/100858097-71d4d380-3485-11eb-84d2-5fbedd9d1b74.png">
