### PR TITLE
Add as_json ContextualFeature

### DIFF
--- a/lib/flip_fab/contextual_feature.rb
+++ b/lib/flip_fab/contextual_feature.rb
@@ -11,6 +11,12 @@ module FlipFab
       persist
     end
 
+    def as_json(options = {})
+      {
+        'feature' => feature.as_json(options)
+      }
+    end
+
     def enabled?
       state == :enabled
     end

--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlipFab
-  base = '1.0.13'
+  base = '1.0.14'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/spec/lib/flip_fab/contextual_feature_spec.rb
+++ b/spec/lib/flip_fab/contextual_feature_spec.rb
@@ -1,5 +1,5 @@
 module FlipFab
-  describe ContextualFeature do
+  describe ContextualFeature do # rubocop:disable Metrics/BlockLength
     let(:override)             {}
     let(:default)              { :disabled }
     let(:persistence_adapters) { [TestPersistence] }
@@ -12,7 +12,6 @@ module FlipFab
       it 'returns only the feature' do
         expect(subject.as_json.keys).to eq(['feature'])
       end
-
     end
 
     describe '.new' do

--- a/spec/lib/flip_fab/contextual_feature_spec.rb
+++ b/spec/lib/flip_fab/contextual_feature_spec.rb
@@ -8,6 +8,13 @@ module FlipFab
     let(:context)              { TestContext.new feature_states, 'example_feature' => override }
     subject { described_class.new feature, context }
 
+    describe '.as_json' do
+      it 'returns only the feature' do
+        expect(subject.as_json.keys).to eq(['feature'])
+      end
+
+    end
+
     describe '.new' do
       it 'assigns the feature' do
         expect(subject.feature).to eq(feature)


### PR DESCRIPTION
Fixes issue where ruby ends up in an infinite recursion when trying to call `as_json` on the journey context.