### PR TITLE
Replace deprecated `set-output` command 

### DIFF
--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -29,7 +29,7 @@ jobs:
           GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
       - name: Get Gem Version
         id: get-gem-version
-        run: echo "::set-output name=GEM_VERSION::$(bundle exec ruby -e 'puts FlipFab::VERSION')"
+        run: echo "GEM_VERSION=$(bundle exec ruby -e 'puts FlipFab::VERSION')" >> $GITHUB_OUTPUT
       - name: Create Release
         uses: actions/github-script@v6
         env:

--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlipFab
-  base = '1.0.17'
+  base = '1.0.18'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"


### PR DESCRIPTION
## What it does

Replaces deprecated `set-output` GitHub Actions command with a use of GitHub environment files.

## Why is it important

`set-output` command is to be disabled and will cause GitHub workflows to fail starting from 1st June 2023.

See [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) for details.