### PR TITLE
AHOY-1204 | Deprecate FlipFab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Flip Fab
+Flip Fab [DEPRECATED]
+----
+
+Status: DEPRECATED
+
+Please use Amplitude Experiment instead for AB testing in Chopin! More [here](https://github.com/simplybusiness/chopin/blob/master/doc/amplitude.md).
+
+----
 
 **Feature flipping... Made FaBuLoUs!**
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,4 +5,4 @@ metadata:
   description: A gem providing persistent, per-user feature flipping to Rack applications
 spec:
   type: library
-  lifecycle: production
+  lifecycle: deprecated

--- a/flip_fab.gemspec
+++ b/flip_fab.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rutabaga', '~> 3.0'
   spec.add_development_dependency 'simplycop', '~> 1.9'
   spec.add_development_dependency 'timecop', '~> 0.8'
+  spec.post_install_message = 'FlipFab is deprecated and everyone should use Amplitude Experiment instead!'
 end

--- a/lib/flip_fab/version.rb
+++ b/lib/flip_fab/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlipFab
-  base = '1.1.20'
+  base = '1.1.21'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"


### PR DESCRIPTION
1. Add postinstall deprecation notice
1. Add deprecated status note to readme
1. Update catalog with deprecated status